### PR TITLE
Implement Yandex Disk logic and fix handlers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,3 +6,12 @@ services:
     env_file:
       - .env
     restart: always
+  db:
+    image: postgres:16-alpine
+    environment:
+      - POSTGRES_PASSWORD=example
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+volumes:
+  db_data:

--- a/handlers/handlers.py
+++ b/handlers/handlers.py
@@ -17,10 +17,9 @@ class RegisterStates(StatesGroup):
     entering_tutor_code = State()
 
 @router.message(Command("start"))
-async def process_start_command(message: types.Message, state: FSMContext):
-    await state.clear()
-    await message.answer("Выберите вашу роль:", reply_markup=main_keyboard_start)
-    await state.set_state(RegisterStates.choosing_role)
+async def process_start_command(message: types.Message):
+    text = f"ID{message.from_user.id}, User: {message.from_user.username}"
+    await message.reply(text, reply_markup=main_keyboard_start)
 
 @router.message(Command("status"))
 async def process_status_command(message: types.Message):
@@ -62,7 +61,7 @@ async def process_status_command(message: types.Message):
 
 @router.message(Command("help"))
 async def process_help_command(message: types.Message):
-    await message.answer("Напишите /start, чтобы зарегистрироваться.\nНапишите /status, чтобы узнать статус.")
+    await message.answer(text="ПОМОГИ!")
 
 @router.callback_query(F.data == "button_student")
 async def handle_student(callback: types.CallbackQuery, state: FSMContext):
@@ -128,6 +127,11 @@ async def handle_tutor(callback: types.CallbackQuery, state: FSMContext):
         parse_mode="Markdown"
     )
     await callback.answer()
+
+
+@router.callback_query(F.data == "continue_button")
+async def callback_continue(callback: types.CallbackQuery):
+    await callback.message.answer(text="Успешно вызван callback!")
 
 
 @router.message()

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,4 @@ SQLAlchemy==2.0.40
 tomli==2.2.1
 typing_extensions==4.12.2
 yarl==1.18.3
+yadisk==3.3.0

--- a/script/Dockerfile
+++ b/script/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.13-slim
+WORKDIR /app
+COPY ../requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY .. .
+CMD ["python3", "-u", "script/main.py"]

--- a/script/__init__.py
+++ b/script/__init__.py
@@ -1,0 +1,6 @@
+"""Business logic package for telegram bot."""
+
+from .classes import YandexBotLogic
+from .db import create_table
+
+__all__ = ["YandexBotLogic", "create_table"]

--- a/script/classes.py
+++ b/script/classes.py
@@ -1,0 +1,62 @@
+"""Business logic class for Yandex Disk integration."""
+
+from __future__ import annotations
+
+import yadisk
+import aiosqlite
+
+from .db import DB_PATH
+
+class YandexBotLogic:
+    """Encapsulates interaction with Yandex Disk API and token storage."""
+
+    def __init__(self, token: str | None = None) -> None:
+        self._token = token
+        self._client = yadisk.AsyncClient(token=token) if token else None
+
+    def __repr__(self) -> str:  # magic method
+        return f"YandexBotLogic(token_set={self._token is not None})"
+
+    @property
+    def token(self) -> str | None:
+        return self._token
+
+    async def save_token(self, user_id: int, token: str) -> None:
+        """Save token for user and update client."""
+        async with aiosqlite.connect(DB_PATH) as db:
+            await db.execute(
+                "INSERT OR REPLACE INTO yadisk_users(user_id, token) VALUES (?, ?)",
+                (user_id, token),
+            )
+            await db.commit()
+        self._token = token
+        self._client = yadisk.AsyncClient(token=token)
+
+    async def get_token(self, user_id: int) -> str | None:
+        """Retrieve token from DB."""
+        async with aiosqlite.connect(DB_PATH) as db:
+            async with db.execute(
+                "SELECT token FROM yadisk_users WHERE user_id=?", (user_id,)
+            ) as cur:
+                row = await cur.fetchone()
+                return row[0] if row else None
+
+    async def check_token(self) -> bool:
+        """Check whether the stored token is valid."""
+        if not self._client:
+            return False
+        try:
+            return await self._client.check_token()
+        except yadisk.exceptions.UnauthorizedError:
+            return False
+
+    async def add_folder(self, path: str) -> bool:
+        """Try to create a folder on Yandex Disk."""
+        if not self._client:
+            return False
+        try:
+            if not await self._client.is_dir(path):
+                await self._client.mkdir(path)
+            return True
+        except yadisk.YaDiskError:
+            return False

--- a/script/db.py
+++ b/script/db.py
@@ -1,0 +1,18 @@
+"""Async helpers for database creation."""
+
+import aiosqlite
+
+DB_PATH = "instance/sqlite.db"
+
+CREATE_TABLE_QUERY = """
+CREATE TABLE IF NOT EXISTS yadisk_users (
+    user_id INTEGER PRIMARY KEY,
+    token TEXT
+);
+"""
+
+async def create_table() -> None:
+    """Create tables required for yadisk integration."""
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(CREATE_TABLE_QUERY)
+        await db.commit()

--- a/script/main.py
+++ b/script/main.py
@@ -1,0 +1,30 @@
+"""Entry point for running bot via the business logic package."""
+
+import asyncio
+from aiogram import Bot, Dispatcher
+from aiogram.fsm.storage.memory import MemoryStorage
+
+from config import TOKEN
+from handlers import all_routers, set_my_commands, set_up_logger
+from .db import create_table
+from .classes import YandexBotLogic
+
+async def main() -> None:
+    bot = Bot(token=TOKEN)
+    dp = Dispatcher(storage=MemoryStorage())
+    dp.include_routers(*all_routers)
+
+    set_up_logger(fname=__name__)
+    await create_table()
+    await set_my_commands(bot)
+
+    logic = YandexBotLogic()
+    print(logic)
+
+    await dp.start_polling(bot)
+
+if __name__ == "__main__":
+    try:
+        asyncio.run(main())
+    except (KeyboardInterrupt, SystemExit):
+        pass


### PR DESCRIPTION
## Summary
- fix handler responses for `/help` and `/start`
- add callback handler `callback_continue`
- introduce `script` package with business logic and DB helpers
- extend docker-compose with a db service
- include `yadisk` library in requirements

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e059e6fc83298451d5d20fa95d41